### PR TITLE
Add preview flag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "engines": {
     "vscode": "^1.29.0"
   },
+  "preview": true,
   "extensionKind": "ui",
   "contributes": {
     "configuration": {


### PR DESCRIPTION
Thank you for this extension and the libraries under-the-hood. 

I think it is a good idea to let the Marketplace, thus people, know that the extension is under development. I did see your caveat in README.md, but I feel the flag should be set nonetheless. 